### PR TITLE
updated code without segmentation fault

### DIFF
--- a/10/doubt_statement.txt
+++ b/10/doubt_statement.txt
@@ -13,9 +13,9 @@ int main() {
 	
 	while(t-->0)
 	{
-	    int n,b;int a[n];
+	    int n,b;
 	    cin>>n>>b;
-	    
+	    int a[n]; //we cannot declare an array with size n when the size of n has not yet been given as input by user, this is causing segmentation fault.
 	    for(int i=0;i<n;i++)
 	    {
 	        cin>>a[i];


### PR DESCRIPTION
the declaration of an array a with size n must be done only after the user inputs the size of n. This prevents the compile time error of segmentation fault.